### PR TITLE
feat(steering): bootstrap project steering docs

### DIFF
--- a/.claude/commands/kiro/steering-custom.md
+++ b/.claude/commands/kiro/steering-custom.md
@@ -1,5 +1,5 @@
 ---
-description: Create custom steering documents for specialized project contexts
+description: Create custom prd.md documents for specialized project contexts
 allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS
 ---
 

--- a/.claude/commands/kiro/steering.md
+++ b/.claude/commands/kiro/steering.md
@@ -1,5 +1,5 @@
 ---
-description: Manage .kiro/steering/ as persistent project knowledge
+description: Manage .kiro/prd.md/ as persistent project knowledge
 allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ build/
 
 ### secret ###
 .env.cached
+.infisical.json
 
 ### AI output ###
 reviews

--- a/.kiro/steering/prd.md
+++ b/.kiro/steering/prd.md
@@ -1,0 +1,126 @@
+# PRD — Tinder 4 Dogs
+
+> **Version:** 1.1 · **Status:** Draft · **Date:** 2026-04-08
+
+---
+
+## Problem Statement
+
+Finding playmates or breeding partners for a dog is today a random and inefficient process: owners rely on chance encounters at the park, with no way to proactively search for compatible dogs by breed, size, temperament, or distance. PawMatch solves this by offering a matchmaking web app that enables dog owners to find, evaluate, and contact each other in a targeted way — turning a casual encounter into a deliberate choice.
+
+---
+
+## Target Users & Personas
+
+### Persona 1 — Marco, owner with a sociable dog
+- **Profile:** 30 years old, lives in the city, owns a 2-year-old Labrador. Uses his smartphone for everything, not technically savvy.
+- **Pain points:** Always goes to the same park; his dog always plays with the same dogs. He'd like variety but doesn't know where to find compatible new playmates.
+- **Goals:** Find dogs of the right size and similar temperament, and organise meetups easily.
+
+### Persona 2 — Giulia, owner interested in breeding
+- **Profile:** 38 years old, owns a female Golden Retriever. Not a professional breeder, but wants to find a suitable partner for a litter.
+- **Pain points:** Doesn't know who to turn to — online options are either disorganised forums or professional breeder sites that feel too formal.
+- **Goals:** Find a breed- and health-compatible male, and be able to communicate with the owner before meeting in person.
+
+---
+
+## Value Proposition
+
+PawMatch is the first dog matchmaking web app designed for everyday owners, combining intelligent compatibility scoring (breed, size, temperament, geolocation) with an integrated chat to organise real-world meetups. Unlike generic forums or chance encounters at the park, PawMatch brings the intentionality and simplicity of Tinder to the world of canine socialisation.
+
+---
+
+## Feature List
+
+### F-01 — Registration & owner profile · Priority: P0
+**Description:** User registration via email and password. The profile includes name, optional photo, and geographic location (city-level by default; more precise if the user explicitly consents).
+**Personas served:** Marco, Giulia
+**User story:** As an owner, I want to create a secure account so that I can use the app and manage my dog's profile.
+**Success metrics:** Profile completion rate > 70% after registration.
+**Constraints / notes:** Data collection and processing must comply with GDPR and nLPD. Explicit consent required for geolocation. Passwords hashed with bcrypt or Argon2.
+
+---
+
+### F-02 — Dog profile · Priority: P0
+**Description:** Each user creates a single dog profile with: name, photos, breed, size, age, sex, temperament (selectable tags: playful, calm, energetic, etc.), optional health/breeding fields (e.g. pedigree, health certificates — not mandatory), and purpose (socialisation / breeding / both).
+**Personas served:** Marco, Giulia
+**User story:** As an owner, I want to create a detailed profile for my dog so that other users can assess compatibility before matching.
+**Success metrics:** ≥ 80% of dog profiles have at least one photo and all mandatory fields filled in.
+**Constraints / notes:** One dog profile per account (multi-dog support deferred to v2). A completed dog profile is required to access the matching feed.
+
+---
+
+### F-03 — Intelligent matching feed · Priority: P0
+**Description:** The user browses a feed of nearby dogs within a configurable radius (5–100 km). The system ranks and filters suggestions based on: geographic distance, breed/size compatibility, temperament, and purpose (socialisation vs breeding). Swipe right (interested) / left (skip). A match is confirmed when both owners express mutual interest.
+**Personas served:** Marco, Giulia
+**User story:** As an owner, I want to see compatible dogs near me so that I can find a good match without scrolling through irrelevant profiles.
+**Success metrics:** ≥ 1 match per active user in the first week; mutual match rate > 15% of right swipes.
+**Constraints / notes:** Compatibility vectors stored in pgvector for semantic search and scoring. Geolocation must never be exposed at address level — minimum approximation of 500 m applied server-side.
+
+---
+
+### F-04 — Owner chat · Priority: P0
+**Description:** Once a mutual match is established, the two owners can open a text chat to organise a meetup or get to know each other better. Chat is accessible only between matched users. Message history is retained indefinitely.
+**Personas served:** Marco, Giulia
+**User story:** As an owner, I want to chat with the owner of a matched dog so that I can safely arrange a meetup.
+**Success metrics:** ≥ 50% of matches lead to at least one message sent.
+**Constraints / notes:** No forced sharing of external contact details. Indefinite message retention; covered in privacy policy.
+
+---
+
+### F-05 — In-app notifications · Priority: P0
+**Description:** Real-time in-app notifications (browser) for: new match, new message received.
+**Personas served:** Marco, Giulia
+**User story:** As an owner, I want to receive a notification when I get a match or a message so that I don't miss any meetup opportunity.
+**Success metrics:** Notification open rate > 40%.
+**Constraints / notes:** Delivered via WebSocket or SSE. No mobile push notifications required for v1.
+
+---
+
+### F-06 — Match history · Priority: P0
+**Description:** Each user can view their list of past matches and conversations, with the ability to reopen any chat.
+**Personas served:** Marco, Giulia
+**User story:** As an owner, I want to see my match and chat history so that I can find past contacts and keep track of organised meetups.
+**Success metrics:** Feature used by ≥ 30% of monthly active users.
+**Constraints / notes:** History visible only to the user themselves. Data retention compliant with GDPR/nLPD policies.
+
+---
+
+## Non-Functional Requirements
+
+| ID | Category | Requirement | Acceptance Criterion | Priority | Source |
+|---|---|---|---|---|---|
+| NFR-01 | Performance | API response time for the matching feed | p95 < 500 ms under normal load | P0 | implicit (pgvector search) |
+| NFR-02 | Security | Authentication & authorisation | JWT with expiry ≤ 1h + refresh token; no sensitive endpoint accessible without a valid token | P0 | implicit |
+| NFR-03 | Privacy / Compliance | GDPR and nLPD compliance | Privacy policy published; explicit consent for geolocation; right to erasure implemented (account + data deleted within 30 days of request) | P0 | explicit |
+| NFR-04 | Security | Geolocation data protection | Coordinates never exposed at exact address level; minimum approximation of 500 m applied server-side | P0 | implicit |
+| NFR-05 | Scalability | Stateless backend | Spring Boot backend must be horizontally scalable — no in-memory session state | P1 | implicit |
+| NFR-06 | Availability | Service uptime | ≥ 99.5% monthly uptime measured via external health check | P1 | unaddressed |
+| NFR-07 | Observability | Structured logging | All 5xx errors logged with trace ID; automated alert if error rate > 1% over 5 min | P1 | implicit |
+| NFR-08 | Reliability | Database migrations | Every Liquibase changeset must include a tested, functional rollback | P0 | explicit |
+| NFR-09 | Usability | UI accessibility | Radix UI components used per WAI-ARIA guidelines; colour contrast meets WCAG AA | P1 | implicit |
+| NFR-10 | Maintainability | Toolchain version management | All runtime versions (Node, Bun, Java, etc.) defined via mise (.mise.toml) and committed to the repository | P0 | explicit |
+| NFR-11 | Portability | Reproducible builds | `bun install --frozen-lockfile` and `mvn verify` must pass in a clean CI environment with no implicit global dependencies | P1 | implicit |
+
+### Unaddressed Categories
+- **Disaster Recovery** — No backup/restore strategy defined. Relevant as soon as user data exists in production.
+- **Rate Limiting** — No limits on swipes or messages to prevent abuse. Should be addressed before user growth scales.
+
+---
+
+## Out of Scope — v1
+- Native mobile app (iOS / Android)
+- Premium profiles or paid subscriptions
+- User review and rating system
+- Professional breeders / B2B features
+- Mobile push notifications
+- Owner identity or dog health verification
+- Content moderation tooling or admin panel
+- Geofencing or group event organisation
+- Multi-dog support per account
+
+---
+
+## Open Questions
+- **Q1 [Operations]:** Who handles infrastructure and on-call for production incidents at launch?
+- **Q2 [Matching]:** Should the search radius default to a specific value within the 5–100 km range, or should the user set it explicitly on first use?

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,28 @@
+# Product Overview
+
+PawMatch is a dog matchmaking web app that helps owners find compatible playmates or breeding partners. It replaces chance park encounters with intentional, scored matching — combining geolocation, breed/temperament compatibility, and in-app chat into one focused tool for everyday dog owners.
+
+## Core Capabilities
+
+1. **Smart matching feed** — ranks nearby dogs by a compatibility score (breed, size, temperament, distance); mutual interest creates a Match
+2. **Dog profiles** — each account manages one dog profile with photos, breed, age, sex, temperament tags, and purpose (socialisation / breeding / both)
+3. **Owner chat** — unlocked only after a mutual match; retains full history
+4. **AI-powered compatibility** — compatibility scored via LLM calls (LiteLLM proxy) and a breed-compatibility knowledge base; fine-tuning pipeline for continuous improvement
+5. **Real-time notifications** — in-app alerts (WebSocket / SSE) for new matches and messages
+
+## Target Use Cases
+
+- Casual owner looking for dog playmates nearby
+- Owner seeking a compatible breeding partner with health/breed filtering
+- Future: rescue coordinator managing multiple profiles (v2)
+
+## Value Proposition
+
+Brings the intentionality and simplicity of swipe-based matching to canine socialisation, backed by an AI compatibility layer rather than random search. Privacy-first: geolocation is approximated server-side (≥ 500 m), no exact addresses ever exposed.
+
+## Out of Scope (v1)
+
+Native mobile app, paid subscriptions, admin/moderation panel, multi-dog accounts, mobile push notifications.
+
+---
+_Focus on patterns and purpose, not exhaustive feature lists_

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,46 @@
+# Project Structure
+
+## Organization Philosophy
+
+Domain-driven with layered sub-packages. Each domain module is self-contained: `model/`, `service/`, `presentation/` live inside the domain folder, not in global layers. Cross-cutting AI infrastructure lives under `ai/`.
+
+## Directory Patterns
+
+### Domain modules
+**Location**: `src/main/kotlin/com/ai4dev/tinderfordogs/<domain>/`
+**Pattern**: `model/` (data classes/entities) → `service/` (business logic, `@Service`) → `presentation/` (`@RestController`)
+**Examples**: `match/`, `support/`
+
+### AI infrastructure
+**Location**: `src/main/kotlin/com/ai4dev/tinderfordogs/ai/`
+**Sub-modules**: `common/` (shared config/clients), `observability/` (Langfuse), `finetuning/` (OpenAI fine-tuning pipeline), `rag/` (retrieval-augmented generation)
+**Pattern**: same `model/` → `service/` → `presentation/` layering within each sub-module
+
+### Resources
+**Location**: `src/main/resources/`
+**Conventions**:
+- `application.yaml` — Spring config; secrets via env-var placeholders (`${VAR:default}`)
+- `prompts/*.yaml` — Langfuse-managed prompt templates (YAML format)
+- `knowledge-base/*.md` — RAG source documents
+- `fine-tuning/*.json` — seed examples for model fine-tuning
+
+### Tests
+**Location**: `src/test/kotlin/` mirroring main package structure
+**Naming**: `<ClassName>Test.kt` — e.g., `DogMatcherServiceTest.kt`
+
+## Naming Conventions
+
+- **Packages**: `lowercase`, domain-first (e.g., `match.service`, `ai.observability.config`)
+- **Classes**: `PascalCase`; controllers end in `Controller`, services in `Service`
+- **Data classes**: noun-only (e.g., `Dog`, `CompatibilityRequest`, `SupportResponse`)
+- **Config beans**: `<Technology>Config` (e.g., `LangfuseConfig`)
+
+## Code Organization Principles
+
+- No global `controller/`, `service/`, `model/` packages — everything is nested under its domain
+- Shared AI utilities go to `ai/common/`; nothing domain-specific leaks there
+- Prompt content lives in Langfuse or `resources/prompts/`, never hardcoded in service classes
+- `application.yaml` only holds config structure; real secrets come from environment
+
+---
+_Document patterns, not file trees. New files following patterns shouldn't require updates_

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,74 @@
+# Technology Stack
+
+## Architecture
+
+Single Spring Boot service (REST/MVC) backed by PostgreSQL. AI calls are proxied through LiteLLM; observability runs through Langfuse. No frontend yet — API-only for v1.
+
+## Core Technologies
+
+- **Language**: Kotlin 2.2.21 (strict JSR-305 null-safety, `all-open` for JPA entities)
+- **Framework**: Spring Boot 4.0.4 — WebMVC (not WebFlux)
+- **Runtime**: Java 24 (Zulu), managed via mise
+- **Build**: Maven (mvnw wrapper) — `./mvnw` always, never system `mvn`
+- **Database**: PostgreSQL via Spring Data JPA + Hibernate (PostgreSQLDialect)
+- **Coroutines**: `kotlinx-coroutines-reactor` for async AI calls
+
+## Key Libraries
+
+- **LiteLLM** — local AI proxy for all LLM calls (configured in `application.yaml` as `litellm.url`)
+- **Langfuse** (`langfuse-java 0.2.0`) — prompt management and AI observability
+- **kotlin-logging-jvm** — structured logging (`KotlinLogging.logger {}`)
+- **Jackson Kotlin module** — JSON serialisation; YAML data format also included
+- **Spring Boot Validation** — bean validation on request models
+
+## Development Standards
+
+### Null Safety
+Kotlin strict JSR-305 mode (`-Xjsr305=strict`). Never use `!!` without explicit justification.
+
+### Code Quality
+- JaCoCo coverage reports generated on `mvn test` (target: `target/site/jacoco/`)
+- `gitleaks` pre-commit for secret scanning
+- Conventional Commits enforced (see CLAUDE.md)
+
+### Testing
+- JUnit 5 + Spring Boot Test slices; MockK for Kotlin mocking
+- Integration tests hit real database (TestContainers pattern expected for DB tests)
+- Coverage: `./mvnw verify` produces JaCoCo report
+
+## Development Environment
+
+### Required Tools (managed via mise / `.tool-versions`)
+```
+java  zulu-25.28.85
+maven 3.9.12
+kotlin 2.3.10
+nodejs 25.8.1
+```
+
+Other required tools: `docker`, `just`, `direnv`, `gitleaks`, `infisical` (or 1Password CLI)
+
+### Required Environment Variables
+`LITELLM_MASTER_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`
+
+### Common Commands
+```bash
+# Dev (auto-reload):  just dev
+# Build:              just build        (./mvnw clean install)
+# Test:               just test         (./mvnw test)
+# Coverage:           just test-coverage (./mvnw verify)
+# AI review:          just review <file>
+# AI gen-tests:       just gen-tests <file>
+# Commit msg:         just commit-msg
+```
+
+## Key Technical Decisions
+
+- **MVC over WebFlux**: simpler coroutine integration; team familiarity
+- **LiteLLM proxy**: all LLM providers routed through a single local endpoint — avoids hardcoding provider SDKs in the app
+- **Langfuse for prompts**: prompts are managed server-side in Langfuse (not hardcoded), fetched at runtime with a configurable TTL cache
+- **pgvector planned**: compatibility vectors to be stored in PostgreSQL pgvector extension for semantic search (not yet implemented)
+- **Secrets via direnv + Infisical/1Password**: no `.env` files committed; `direnv allow` loads env from secret manager
+
+---
+_Document standards and patterns, not every dependency_


### PR DESCRIPTION
## Summary

- Add `.kiro/steering/prd.md` — full PawMatch PRD (v1.1) with features, NFRs, personas, and open questions
- Add `.kiro/steering/product.md` — product purpose, core capabilities, and value proposition derived from codebase analysis
- Add `.kiro/steering/tech.md` — Kotlin/Spring Boot 4/LiteLLM/Langfuse stack, conventions, and key architectural decisions
- Add `.kiro/steering/structure.md` — domain-driven package layout, naming conventions, and resource organization patterns
- Update `.gitignore` to exclude `.infisical.json`
- Sync kiro command descriptions in `.claude/commands/kiro/`

## Test plan

- [ ] Verify steering files load correctly as project memory in next `/kiro:steering` sync run
- [ ] Confirm `.infisical.json` is no longer tracked by git
- [ ] Review steering content for accuracy against current codebase state

🤖 Generated with [Claude Code](https://claude.com/claude-code)